### PR TITLE
[REVIEW] Initial Esspresso implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,14 @@ android:
 
     - extra
 
-before_script:
+before_install:
     - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
-    - emulator -avd test -no-skin -no-audio -no-window &
+    - emulator -avd test -skin QVGA -no-audio -no-window &
+
+before_script:
     - android-wait-for-emulator
     - adb shell input keyevent 82 &
 
 script:
-    - ./gradlew build connectedAndroidTest
+    - ./gradlew test
+    - ./gradlew connectedAndroidTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,20 +17,7 @@ android:
     # The SDK version used to compile your project
     - android-22
 
-    # Emulator for UI testing
-    # version 21 is already provided by travis.
-    - sys-img-armeabi-v7a-android-21
-
     - extra
 
-before_install:
-    - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
-    - emulator -avd test -skin QVGA -no-audio -no-window &
-
-before_script:
-    - android-wait-for-emulator
-    - adb shell input keyevent 82 &
-
 script:
-    - ./gradlew test
-    - ./gradlew connectedAndroidTest
+    - ./gradlew build

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,6 +97,7 @@ def packageName = 'com.tehmou.rxbookapp'
 def command = "$adb shell pm grant $packageName android.permission.SET_ANIMATION_SCALE".split(' ')
 
 task grantAnimationPermission(type: Exec, dependsOn: 'installDebug') {
+    println ""
     println '================================================='
     println 'Granting permission to disable animations'
     commandLine command

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,5 +88,27 @@ dependencies {
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
     androidTestCompile "com.google.dexmaker:dexmaker:1.2"
     androidTestCompile "com.google.dexmaker:dexmaker-mockito:1.2"
+}
 
+// Get the path to ADB.  Required when running tests directly from Android Studio.
+// Source: http://stackoverflow.com/a/26771087/112705
+def adb = android.getAdbExe().toString()
+def packageName = 'com.tehmou.rxbookapp'
+def command = "$adb shell pm grant $packageName android.permission.SET_ANIMATION_SCALE".split(' ')
+
+task grantAnimationPermission(type: Exec, dependsOn: 'installDebug') {
+    println '================================================='
+    println 'Granting permission to disable animations'
+    commandLine command
+    println '================================================='
+}
+
+afterEvaluate {
+    // When launching individual tests from Android Studio, it seems that only the assemble tasks
+    // get called directly, not the install* versions
+    tasks.each { task ->
+        if (task.name.startsWith('assembleDebugAndroidTest')) {
+            task.dependsOn grantAnimationPermission
+        }
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,8 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
+
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     dexOptions {
         preDexLibraries false
@@ -48,6 +50,10 @@ android {
         // https://github.com/square/okio/issues/58
         warning 'InvalidPackage'
     }
+
+    packagingOptions {
+        exclude 'LICENSE.txt'
+    }
 }
 
 retrolambda {
@@ -71,8 +77,15 @@ dependencies {
     // Unit test build
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
-
     testCompile 'org.powermock:powermock-api-mockito:1.6.1'
     testCompile 'org.powermock:powermock-module-junit4:1.6.1'
+
+    androidTestCompile 'com.android.support.test:runner:0.2'
+    androidTestCompile 'com.android.support.test:rules:0.2'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.1'
+    androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.1'
+    androidTestCompile 'org.mockito:mockito-core:1.10.19'
+    androidTestCompile "com.google.dexmaker:dexmaker:1.2"
+    androidTestCompile "com.google.dexmaker:dexmaker-mockito:1.2"
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     testCompile 'org.powermock:powermock-api-mockito:1.6.1'
     testCompile 'org.powermock:powermock-module-junit4:1.6.1'
 
+    androidTestCompile 'com.android.support:support-annotations:22.1.1'
     androidTestCompile 'com.android.support.test:runner:0.2'
     androidTestCompile 'com.android.support.test:rules:0.2'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.1'

--- a/app/src/androidTest/java/com/tehmou/rxbookapp/activities/ChooseRepositoryActivityTest.java
+++ b/app/src/androidTest/java/com/tehmou/rxbookapp/activities/ChooseRepositoryActivityTest.java
@@ -1,0 +1,41 @@
+package com.tehmou.rxbookapp.activities;
+
+import com.tehmou.rxbookapp.R;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+/**
+ * Created by Pawel Polanski on 5/27/15.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class ChooseRepositoryActivityTest {
+    @Rule
+    public ActivityTestRule<ChooseRepositoryActivity> activityRule = new ActivityTestRule<>(ChooseRepositoryActivity.class);
+
+    @Test
+    public void testInitialActivityState() {
+        onView(withId(R.id.repositories_list_view)).check(matches(isDisplayed()));
+        onView(withId(R.id.repositories_status_text)).check(matches(isDisplayed()));
+        onView(withId(R.id.repositories_search)).check(matches(isDisplayed()));
+        onView(withId(R.id.repositories_status_text)).check(matches(withText((""))));
+    }
+
+    @Test
+    public void testCanPerformInsertingSearchText() {
+        onView(withId(R.id.repositories_search)).perform(typeText("rx-android-architecture"));
+    }
+}

--- a/app/src/androidTest/java/com/tehmou/rxbookapp/activities/ChooseRepositoryActivityTest.java
+++ b/app/src/androidTest/java/com/tehmou/rxbookapp/activities/ChooseRepositoryActivityTest.java
@@ -1,11 +1,17 @@
 package com.tehmou.rxbookapp.activities;
 
 import com.tehmou.rxbookapp.R;
+import com.tehmou.rxbookapp.activities.utils.SystemAnimations;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
@@ -26,6 +32,11 @@ public class ChooseRepositoryActivityTest {
     @Rule
     public ActivityTestRule<ChooseRepositoryActivity> activityRule = new ActivityTestRule<>(ChooseRepositoryActivity.class);
 
+    @BeforeClass
+    public static void setUp() {
+        SystemAnimations.disableAll(InstrumentationRegistry.getContext());
+    }
+
     @Test
     public void testInitialActivityState() {
         onView(withId(R.id.repositories_list_view)).check(matches(isDisplayed()));
@@ -37,5 +48,10 @@ public class ChooseRepositoryActivityTest {
     @Test
     public void testCanPerformInsertingSearchText() {
         onView(withId(R.id.repositories_search)).perform(typeText("rx-android-architecture"));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        SystemAnimations.enableAll(InstrumentationRegistry.getContext());
     }
 }

--- a/app/src/androidTest/java/com/tehmou/rxbookapp/activities/MainActivityTest.java
+++ b/app/src/androidTest/java/com/tehmou/rxbookapp/activities/MainActivityTest.java
@@ -1,0 +1,45 @@
+package com.tehmou.rxbookapp.activities;
+
+import com.tehmou.rxbookapp.R;
+import com.tehmou.rxbookapp.activities.MainActivity;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.ActivityInstrumentationTestCase2;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.core.IsNot.not;
+/**
+ * Created by Pawel Polanski on 4/27/15.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class MainActivityTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class);
+
+    @Test
+    public void testInitialActivityState() {
+        onView(withText(R.string.repository_fragment_intro)).check(matches(isDisplayed()));
+        onView(withText(R.string.repository_fragment_change)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void testPressingChangeButtonLaunchesRepositoriesActivity() {
+        onView(withText(R.string.repository_fragment_change)).perform(click());
+        onView(withId(R.id.repositories_view)).check(matches(isDisplayed()));
+    }
+
+}

--- a/app/src/androidTest/java/com/tehmou/rxbookapp/activities/MainActivityTest.java
+++ b/app/src/androidTest/java/com/tehmou/rxbookapp/activities/MainActivityTest.java
@@ -2,11 +2,17 @@ package com.tehmou.rxbookapp.activities;
 
 import com.tehmou.rxbookapp.R;
 import com.tehmou.rxbookapp.activities.MainActivity;
+import com.tehmou.rxbookapp.activities.utils.SystemAnimations;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -30,6 +36,11 @@ public class MainActivityTest {
     @Rule
     public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class);
 
+    @BeforeClass
+    public static void setUp() {
+        SystemAnimations.disableAll(InstrumentationRegistry.getContext());
+    }
+
     @Test
     public void testInitialActivityState() {
         onView(withText(R.string.repository_fragment_intro)).check(matches(isDisplayed()));
@@ -40,6 +51,11 @@ public class MainActivityTest {
     public void testPressingChangeButtonLaunchesRepositoriesActivity() {
         onView(withText(R.string.repository_fragment_change)).perform(click());
         onView(withId(R.id.repositories_view)).check(matches(isDisplayed()));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        SystemAnimations.enableAll(InstrumentationRegistry.getContext());
     }
 
 }

--- a/app/src/androidTest/java/com/tehmou/rxbookapp/activities/utils/SystemAnimations.java
+++ b/app/src/androidTest/java/com/tehmou/rxbookapp/activities/utils/SystemAnimations.java
@@ -1,0 +1,77 @@
+package com.tehmou.rxbookapp.activities.utils;
+
+/**
+ * Created by Pawel Polanski on 5/22/15.
+ */
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.IBinder;
+
+import java.lang.reflect.Method;
+
+/**
+ * Disable animations so that they do not interfere with Espresso tests.
+ *
+ * Source: https://code.google.com/p/android-test-kit/wiki/DisablingAnimations
+ */
+public final class SystemAnimations {
+    private static final String ANIMATION_PERMISSION = "android.permission.SET_ANIMATION_SCALE";
+    private static final float DISABLED = 0.0f;
+    private static final float DEFAULT = 1.0f;
+
+    private final Context context;
+
+    public SystemAnimations(Context context) {
+        this.context = context;
+    }
+
+    public void disableAll() {
+        int permStatus = context.checkCallingOrSelfPermission(ANIMATION_PERMISSION);
+        if (permStatus == PackageManager.PERMISSION_GRANTED) {
+            setSystemAnimationsScale(DISABLED);
+        } else {
+            throw new IllegalStateException("Application not granted access to animations");
+        }
+    }
+
+    public void enableAll() {
+        int permStatus = context.checkCallingOrSelfPermission(ANIMATION_PERMISSION);
+        if (permStatus == PackageManager.PERMISSION_GRANTED) {
+            setSystemAnimationsScale(DEFAULT);
+        } else {
+            throw new IllegalStateException("Application not granted access to animations");
+        }
+    }
+
+    private void setSystemAnimationsScale(float animationScale) {
+        try {
+            Class<?> windowManagerStubClazz = Class.forName("android.view.IWindowManager$Stub");
+            Method asInterface = windowManagerStubClazz.getDeclaredMethod("asInterface", IBinder.class);
+            Class<?> serviceManagerClazz = Class.forName("android.os.ServiceManager");
+            Method getService = serviceManagerClazz.getDeclaredMethod("getService", String.class);
+            Class<?> windowManagerClazz = Class.forName("android.view.IWindowManager");
+            Method setAnimationScales = windowManagerClazz.getDeclaredMethod("setAnimationScales", float[].class);
+            Method getAnimationScales = windowManagerClazz.getDeclaredMethod("getAnimationScales");
+
+            IBinder windowManagerBinder = (IBinder) getService.invoke(null, "window");
+            Object windowManagerObj = asInterface.invoke(null, windowManagerBinder);
+            float[] currentScales = (float[]) getAnimationScales.invoke(windowManagerObj);
+            for (int i = 0; i < currentScales.length; i++) {
+                currentScales[i] = animationScale;
+            }
+            setAnimationScales.invoke(windowManagerObj, new Object[]{currentScales});
+        } catch (Exception e) {
+            throw new InternalError("Could not change animation scale to " + animationScale);
+        }
+    }
+
+    public static void disableAll(Context context) {
+        new SystemAnimations(context).disableAll();
+    }
+
+    public static void enableAll(Context context) {
+        new SystemAnimations(context).enableAll();
+    }
+
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        package="com.tehmou.rxbookapp">
+
+    <!-- Disable animations on debug builds so that the animations do not interfere with Espresso
+         tests.  Adding this permission to the manifest is not sufficient - you must also grant the
+         permission over adb! -->
+    <uses-permission android:name="android.permission.SET_ANIMATION_SCALE" />
+
+</manifest>


### PR DESCRIPTION
Not adding Travis support as it has a cap of 3GB which is not enough for connected tests.

The connected tests can be run on a local machine for now.