### PR TITLE
Add support-annotations to dependencies

### DIFF
--- a/rxandroidarchitecture/build.gradle
+++ b/rxandroidarchitecture/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:22.2.0'
     compile 'io.reactivex:rxjava:1.0.11'
     compile 'io.reactivex:rxandroid:0.24.0'
+    compile 'com.android.support:support-annotations:22.2.0'
 
     // Unit test build
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Not sure if I am missing something but the master branch is not built. support-annotations is missing in build.gradle.